### PR TITLE
feat: enable distributed tracing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7586,9 +7586,6 @@ dependencies = [
  "op-alloy-consensus 0.20.0",
  "op-alloy-network",
  "op-revm",
- "opentelemetry",
- "opentelemetry-otlp",
- "opentelemetry_sdk",
  "rdkafka",
  "reth-errors",
  "reth-optimism-evm",
@@ -7598,9 +7595,9 @@ dependencies = [
  "serde_json",
  "tips-audit",
  "tips-datastore",
+ "tips-tracing",
  "tokio",
  "tracing",
- "tracing-opentelemetry",
  "tracing-subscriber 0.3.20",
  "url",
 ]
@@ -7644,6 +7641,19 @@ dependencies = [
  "tracing",
  "tracing-subscriber 0.3.20",
  "url",
+]
+
+[[package]]
+name = "tips-tracing"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "opentelemetry",
+ "opentelemetry-otlp",
+ "opentelemetry_sdk",
+ "tracing",
+ "tracing-opentelemetry",
+ "tracing-subscriber 0.3.20",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -407,7 +407,7 @@ dependencies = [
  "serde_json",
  "tokio",
  "tokio-stream",
- "tower",
+ "tower 0.5.2",
  "tracing",
  "url",
  "wasmtimer",
@@ -645,7 +645,7 @@ dependencies = [
  "serde_json",
  "thiserror",
  "tokio",
- "tower",
+ "tower 0.5.2",
  "tracing",
  "url",
  "wasmtimer",
@@ -661,7 +661,7 @@ dependencies = [
  "alloy-transport",
  "reqwest",
  "serde_json",
- "tower",
+ "tower 0.5.2",
  "tracing",
  "url",
 ]
@@ -1462,7 +1462,7 @@ dependencies = [
  "rustls-pki-types",
  "tokio",
  "tokio-rustls 0.26.3",
- "tower",
+ "tower 0.5.2",
  "tracing",
 ]
 
@@ -1582,6 +1582,53 @@ dependencies = [
  "aws-smithy-types",
  "rustc_version 0.4.1",
  "tracing",
+]
+
+[[package]]
+name = "axum"
+version = "0.7.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edca88bc138befd0323b20752846e6587272d3b03b0343c8ea28a6f819e6e71f"
+dependencies = [
+ "async-trait",
+ "axum-core",
+ "bytes",
+ "futures-util",
+ "http 1.3.1",
+ "http-body 1.0.1",
+ "http-body-util",
+ "itoa",
+ "matchit",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustversion",
+ "serde",
+ "sync_wrapper",
+ "tower 0.5.2",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09f2bd6146b97ae3359fa0cc6d6b376d9539582c7b4220f041a33ec24c226199"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "futures-util",
+ "http 1.3.1",
+ "http-body 1.0.1",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "rustversion",
+ "sync_wrapper",
+ "tower-layer",
+ "tower-service",
 ]
 
 [[package]]
@@ -3254,6 +3301,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-timeout"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b90d566bffbce6a75bd8b09a05aa8c2cb1fabb6cb348f8840c9e4c90a0d83b0"
+dependencies = [
+ "hyper 1.7.0",
+ "hyper-util",
+ "pin-project-lite",
+ "tokio",
+ "tower-service",
+]
+
+[[package]]
 name = "hyper-tls"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3287,7 +3347,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.0",
  "tokio",
  "tower-service",
  "tracing",
@@ -3643,7 +3703,7 @@ dependencies = [
  "serde_json",
  "thiserror",
  "tokio",
- "tower",
+ "tower 0.5.2",
  "tracing",
 ]
 
@@ -3683,7 +3743,7 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tokio-util",
- "tower",
+ "tower 0.5.2",
  "tracing",
 ]
 
@@ -3760,7 +3820,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07033963ba89ebaf1584d767badaa2e8fcec21aedea6b8c0346d487d49c28667"
 dependencies = [
  "cfg-if",
- "windows-targets 0.48.5",
+ "windows-targets 0.53.3",
 ]
 
 [[package]]
@@ -3927,6 +3987,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "matchit"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
+
+[[package]]
 name = "md-5"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3963,6 +4029,12 @@ dependencies = [
  "regex",
  "syn 2.0.106",
 ]
+
+[[package]]
+name = "mime"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
 name = "minimal-lexical"
@@ -4384,6 +4456,92 @@ dependencies = [
 ]
 
 [[package]]
+name = "opentelemetry"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "236e667b670a5cdf90c258f5a55794ec5ac5027e960c224bff8367a59e1e6426"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "js-sys",
+ "pin-project-lite",
+ "thiserror",
+ "tracing",
+]
+
+[[package]]
+name = "opentelemetry-http"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8863faf2910030d139fb48715ad5ff2f35029fc5f244f6d5f689ddcf4d26253"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "http 1.3.1",
+ "opentelemetry",
+ "reqwest",
+ "tracing",
+]
+
+[[package]]
+name = "opentelemetry-otlp"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5bef114c6d41bea83d6dc60eb41720eedd0261a67af57b66dd2b84ac46c01d91"
+dependencies = [
+ "async-trait",
+ "futures-core",
+ "http 1.3.1",
+ "opentelemetry",
+ "opentelemetry-http",
+ "opentelemetry-proto",
+ "opentelemetry_sdk",
+ "prost",
+ "reqwest",
+ "serde_json",
+ "thiserror",
+ "tokio",
+ "tonic",
+ "tracing",
+]
+
+[[package]]
+name = "opentelemetry-proto"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56f8870d3024727e99212eb3bb1762ec16e255e3e6f58eeb3dc8db1aa226746d"
+dependencies = [
+ "base64 0.22.1",
+ "hex",
+ "opentelemetry",
+ "opentelemetry_sdk",
+ "prost",
+ "serde",
+ "tonic",
+]
+
+[[package]]
+name = "opentelemetry_sdk"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84dfad6042089c7fc1f6118b7040dc2eb4ab520abbf410b79dc481032af39570"
+dependencies = [
+ "async-trait",
+ "futures-channel",
+ "futures-executor",
+ "futures-util",
+ "glob",
+ "opentelemetry",
+ "percent-encoding",
+ "rand 0.8.5",
+ "serde_json",
+ "thiserror",
+ "tokio",
+ "tokio-stream",
+ "tracing",
+]
+
+[[package]]
 name = "outref"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4759,6 +4917,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "prost"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2796faa41db3ec313a31f7624d9286acf277b52de526150b7e69f3debf891ee5"
+dependencies = [
+ "bytes",
+ "prost-derive",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
+dependencies = [
+ "anyhow",
+ "itertools 0.14.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
+]
+
+[[package]]
 name = "quick-error"
 version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4777,7 +4958,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash 2.1.1",
  "rustls 0.23.31",
- "socket2 0.5.10",
+ "socket2 0.6.0",
  "thiserror",
  "tokio",
  "tracing",
@@ -4814,7 +4995,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.0",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -5042,7 +5223,9 @@ checksum = "d429f34c8092b2d42c7c93cec323bb4adeb7c67698f70839adec842ec10c7ceb"
 dependencies = [
  "base64 0.22.1",
  "bytes",
+ "futures-channel",
  "futures-core",
+ "futures-util",
  "http 1.3.1",
  "http-body 1.0.1",
  "http-body-util",
@@ -5066,7 +5249,7 @@ dependencies = [
  "tokio",
  "tokio-native-tls",
  "tokio-rustls 0.26.3",
- "tower",
+ "tower 0.5.2",
  "tower-http",
  "tower-service",
  "url",
@@ -7403,6 +7586,9 @@ dependencies = [
  "op-alloy-consensus 0.20.0",
  "op-alloy-network",
  "op-revm",
+ "opentelemetry",
+ "opentelemetry-otlp",
+ "opentelemetry_sdk",
  "rdkafka",
  "reth-errors",
  "reth-optimism-evm",
@@ -7414,6 +7600,7 @@ dependencies = [
  "tips-datastore",
  "tokio",
  "tracing",
+ "tracing-opentelemetry",
  "tracing-subscriber 0.3.20",
  "url",
 ]
@@ -7592,6 +7779,56 @@ dependencies = [
 ]
 
 [[package]]
+name = "tonic"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877c5b330756d856ffcc4553ab34a5684481ade925ecc54bcd1bf02b1d0d4d52"
+dependencies = [
+ "async-stream",
+ "async-trait",
+ "axum",
+ "base64 0.22.1",
+ "bytes",
+ "h2 0.4.12",
+ "http 1.3.1",
+ "http-body 1.0.1",
+ "http-body-util",
+ "hyper 1.7.0",
+ "hyper-timeout",
+ "hyper-util",
+ "percent-encoding",
+ "pin-project",
+ "prost",
+ "socket2 0.5.10",
+ "tokio",
+ "tokio-stream",
+ "tower 0.4.13",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tower"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "indexmap 1.9.3",
+ "pin-project",
+ "pin-project-lite",
+ "rand 0.8.5",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
 name = "tower"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7619,7 +7856,7 @@ dependencies = [
  "http-body 1.0.1",
  "iri-string",
  "pin-project-lite",
- "tower",
+ "tower 0.5.2",
  "tower-layer",
  "tower-service",
 ]
@@ -7688,6 +7925,24 @@ dependencies = [
  "log",
  "once_cell",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-opentelemetry"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "721f2d2569dce9f3dfbbddee5906941e953bfcdf736a62da3377f5751650cc36"
+dependencies = [
+ "js-sys",
+ "once_cell",
+ "opentelemetry",
+ "opentelemetry_sdk",
+ "smallvec",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
+ "tracing-subscriber 0.3.20",
+ "web-time",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,16 @@ op-alloy-network = {version = "0.20.0"}
 tokio = { version = "1.47.1", features = ["full"] }
 tracing = "0.1.41"
 tracing-subscriber = { version = "0.3.20", features = ["env-filter"] }
+opentelemetry = { version = "0.28.0", features = ["trace"] }
+opentelemetry-otlp = { version = "0.28.0", features = [
+    "http-proto",
+    "http-json",
+    "reqwest-client",
+    "trace",
+    "grpc-tonic",
+] }
+opentelemetry_sdk = { version = "0.28.0", features = ["rt-tokio"] }
+tracing-opentelemetry = "0.29.0"
 anyhow = "1.0.99"
 clap = { version = "4.5.47", features = ["derive", "env"] }
 url = "2.5.7"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = ["crates/datastore", "crates/audit", "crates/ingress-rpc", "crates/maintenance", "crates/ingress-writer"]
+members = ["crates/datastore", "crates/audit", "crates/ingress-rpc", "crates/maintenance", "crates/ingress-writer", "crates/tracing"]
 resolver = "2"
 
 [workspace.dependencies]
@@ -7,6 +7,7 @@ tips-datastore = { path = "crates/datastore" }
 tips-audit = { path = "crates/audit" }
 tips-maintenance = { path = "crates/maintenance" }
 tips-ingress-writer = { path = "crates/ingress-writer" }
+tips-tracing = { path = "crates/tracing" }
 
 
 # Reth

--- a/crates/audit/src/bin/main.rs
+++ b/crates/audit/src/bin/main.rs
@@ -87,6 +87,14 @@ async fn main() -> Result<()> {
         "Starting audit archiver"
     );
 
+    if args.tracing_enabled {
+        init_tracing(
+            env!("CARGO_PKG_NAME").to_string(),
+            env!("CARGO_PKG_VERSION").to_string(),
+            args.tracing_otlp_endpoint,
+        )?;
+    }
+
     let consumer = create_kafka_consumer(&args.kafka_brokers, &args.kafka_group_id)?;
     consumer.subscribe(&[&args.kafka_topic])?;
 

--- a/crates/ingress-rpc/Cargo.toml
+++ b/crates/ingress-rpc/Cargo.toml
@@ -36,3 +36,8 @@ revm-context-interface.workspace = true
 alloy-signer-local.workspace = true
 reth-optimism-evm.workspace = true
 reth-errors.workspace = true
+opentelemetry.workspace = true
+opentelemetry-otlp.workspace = true
+opentelemetry_sdk.workspace = true
+tracing-opentelemetry.workspace = true
+

--- a/crates/ingress-rpc/Cargo.toml
+++ b/crates/ingress-rpc/Cargo.toml
@@ -10,6 +10,7 @@ path = "src/main.rs"
 [dependencies]
 tips-datastore.workspace = true
 tips-audit.workspace = true
+tips-tracing.workspace = true
 jsonrpsee.workspace = true
 alloy-rpc-types-mev.workspace = true
 alloy-primitives.workspace = true
@@ -36,8 +37,4 @@ revm-context-interface.workspace = true
 alloy-signer-local.workspace = true
 reth-optimism-evm.workspace = true
 reth-errors.workspace = true
-opentelemetry.workspace = true
-opentelemetry-otlp.workspace = true
-opentelemetry_sdk.workspace = true
-tracing-opentelemetry.workspace = true
 

--- a/crates/ingress-rpc/src/main.rs
+++ b/crates/ingress-rpc/src/main.rs
@@ -2,12 +2,21 @@ use alloy_provider::{ProviderBuilder, RootProvider};
 use clap::Parser;
 use jsonrpsee::server::Server;
 use op_alloy_network::Optimism;
+use opentelemetry::{global, KeyValue};
+use opentelemetry_sdk::propagation::TraceContextPropagator;
+use opentelemetry_otlp::WithExportConfig;
+use anyhow::Context as _;
 use rdkafka::ClientConfig;
 use rdkafka::producer::FutureProducer;
 use std::net::IpAddr;
 use tracing::{info, warn};
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
 use url::Url;
+use opentelemetry_sdk::Resource;
+use opentelemetry::trace::TracerProvider;
+use tracing_subscriber::filter::Targets;
+use tracing_subscriber::filter::LevelFilter;
+use tracing_opentelemetry::OpenTelemetryLayer;
 
 mod queue;
 mod service;
@@ -56,6 +65,12 @@ struct Config {
 
     #[arg(long, env = "TIPS_INGRESS_LOG_LEVEL", default_value = "info")]
     log_level: String,
+
+    #[arg(long, env = "TIPS_INGRESS_TRACING_ENABLED", default_value = "false")]
+    tracing_enabled: bool,
+
+    #[arg(long, env = "TIPS_INGRESS_TRACING_OTLP_ENDPOINT", default_value = "http://localhost:4317")]
+    tracing_otlp_endpoint: String,
 }
 
 #[tokio::main]
@@ -92,6 +107,36 @@ async fn main() -> anyhow::Result<()> {
         port = config.port,
         mempool_url = %config.mempool_url
     );
+
+    // from https://github.com/flashbots/rollup-boost/blob/08ebd3e75a8f4c7ebc12db13b042dee04e132c05/crates/rollup-boost/src/tracing.rs#L127
+    if config.tracing_enabled {
+        global::set_text_map_propagator(TraceContextPropagator::new());
+        let otlp_exporter = opentelemetry_otlp::SpanExporter::builder()
+            .with_tonic()
+            .with_endpoint(&config.tracing_otlp_endpoint)
+            .build()
+            .context("Failed to create OTLP exporter")?;
+        let provider_builder = opentelemetry_sdk::trace::SdkTracerProvider::builder()
+            .with_batch_exporter(otlp_exporter)
+            .with_resource(
+                Resource::builder_empty()
+                    .with_attributes([
+                        KeyValue::new("service.name", env!("CARGO_PKG_NAME")),
+                        KeyValue::new("service.version", env!("CARGO_PKG_VERSION")),
+                    ])
+                    .build(),
+            );
+            let provider = provider_builder.build();
+            let tracer = provider.tracer(env!("CARGO_PKG_NAME"));
+            
+            let trace_filter = Targets::new()
+                .with_default(LevelFilter::OFF)
+                .with_target("tips_ingress_rpc", LevelFilter::TRACE);
+
+            tracing::subscriber::set_global_default(
+                tracing_subscriber::registry().with(trace_filter).with(OpenTelemetryLayer::new(tracer)),
+            )?;
+    }
 
     let provider: RootProvider<Optimism> = ProviderBuilder::new()
         .disable_recommended_fillers()

--- a/crates/ingress-rpc/src/main.rs
+++ b/crates/ingress-rpc/src/main.rs
@@ -1,22 +1,12 @@
 use alloy_provider::{ProviderBuilder, RootProvider};
-use anyhow::Context as _;
 use clap::Parser;
 use jsonrpsee::server::Server;
 use op_alloy_network::Optimism;
-use opentelemetry::trace::TracerProvider;
-use opentelemetry::{KeyValue, global};
-use opentelemetry_otlp::SpanExporter;
-use opentelemetry_otlp::WithExportConfig;
-use opentelemetry_sdk::Resource;
-use opentelemetry_sdk::propagation::TraceContextPropagator;
-use opentelemetry_sdk::trace::SdkTracerProvider;
 use rdkafka::ClientConfig;
 use rdkafka::producer::FutureProducer;
 use std::net::IpAddr;
 use tracing::{info, warn};
-use tracing_opentelemetry::OpenTelemetryLayer;
-use tracing_subscriber::filter::LevelFilter;
-use tracing_subscriber::filter::Targets;
+use tips_tracing::init_tracing;
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
 use url::Url;
 
@@ -114,35 +104,11 @@ async fn main() -> anyhow::Result<()> {
         mempool_url = %config.mempool_url
     );
 
-    // from https://github.com/flashbots/rollup-boost/blob/08ebd3e75a8f4c7ebc12db13b042dee04e132c05/crates/rollup-boost/src/tracing.rs#L127
     if config.tracing_enabled {
-        global::set_text_map_propagator(TraceContextPropagator::new());
-        let otlp_exporter = SpanExporter::builder()
-            .with_tonic()
-            .with_endpoint(&config.tracing_otlp_endpoint)
-            .build()
-            .context("Failed to create OTLP exporter")?;
-        let provider_builder = SdkTracerProvider::builder()
-            .with_batch_exporter(otlp_exporter)
-            .with_resource(
-                Resource::builder_empty()
-                    .with_attributes([
-                        KeyValue::new("service.name", env!("CARGO_PKG_NAME")),
-                        KeyValue::new("service.version", env!("CARGO_PKG_VERSION")),
-                    ])
-                    .build(),
-            );
-        let provider = provider_builder.build();
-        let tracer = provider.tracer(env!("CARGO_PKG_NAME"));
-
-        let trace_filter = Targets::new()
-            .with_default(LevelFilter::OFF)
-            .with_target(env!("CARGO_PKG_NAME"), LevelFilter::TRACE);
-
-        tracing::subscriber::set_global_default(
-            tracing_subscriber::registry()
-                .with(trace_filter)
-                .with(OpenTelemetryLayer::new(tracer)),
+        init_tracing(
+            env!("CARGO_PKG_NAME").to_string(),
+            env!("CARGO_PKG_VERSION").to_string(),
+            config.tracing_otlp_endpoint,
         )?;
     }
 

--- a/crates/ingress-rpc/src/main.rs
+++ b/crates/ingress-rpc/src/main.rs
@@ -1,22 +1,24 @@
 use alloy_provider::{ProviderBuilder, RootProvider};
+use anyhow::Context as _;
 use clap::Parser;
 use jsonrpsee::server::Server;
 use op_alloy_network::Optimism;
-use opentelemetry::{global, KeyValue};
-use opentelemetry_sdk::propagation::TraceContextPropagator;
+use opentelemetry::trace::TracerProvider;
+use opentelemetry::{KeyValue, global};
+use opentelemetry_otlp::SpanExporter;
 use opentelemetry_otlp::WithExportConfig;
-use anyhow::Context as _;
+use opentelemetry_sdk::Resource;
+use opentelemetry_sdk::propagation::TraceContextPropagator;
+use opentelemetry_sdk::trace::SdkTracerProvider;
 use rdkafka::ClientConfig;
 use rdkafka::producer::FutureProducer;
 use std::net::IpAddr;
 use tracing::{info, warn};
+use tracing_opentelemetry::OpenTelemetryLayer;
+use tracing_subscriber::filter::LevelFilter;
+use tracing_subscriber::filter::Targets;
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
 use url::Url;
-use opentelemetry_sdk::Resource;
-use opentelemetry::trace::TracerProvider;
-use tracing_subscriber::filter::Targets;
-use tracing_subscriber::filter::LevelFilter;
-use tracing_opentelemetry::OpenTelemetryLayer;
 
 mod queue;
 mod service;
@@ -69,7 +71,11 @@ struct Config {
     #[arg(long, env = "TIPS_INGRESS_TRACING_ENABLED", default_value = "false")]
     tracing_enabled: bool,
 
-    #[arg(long, env = "TIPS_INGRESS_TRACING_OTLP_ENDPOINT", default_value = "http://localhost:4317")]
+    #[arg(
+        long,
+        env = "TIPS_INGRESS_TRACING_OTLP_ENDPOINT",
+        default_value = "http://localhost:4317"
+    )]
     tracing_otlp_endpoint: String,
 }
 
@@ -111,12 +117,12 @@ async fn main() -> anyhow::Result<()> {
     // from https://github.com/flashbots/rollup-boost/blob/08ebd3e75a8f4c7ebc12db13b042dee04e132c05/crates/rollup-boost/src/tracing.rs#L127
     if config.tracing_enabled {
         global::set_text_map_propagator(TraceContextPropagator::new());
-        let otlp_exporter = opentelemetry_otlp::SpanExporter::builder()
+        let otlp_exporter = SpanExporter::builder()
             .with_tonic()
             .with_endpoint(&config.tracing_otlp_endpoint)
             .build()
             .context("Failed to create OTLP exporter")?;
-        let provider_builder = opentelemetry_sdk::trace::SdkTracerProvider::builder()
+        let provider_builder = SdkTracerProvider::builder()
             .with_batch_exporter(otlp_exporter)
             .with_resource(
                 Resource::builder_empty()
@@ -126,16 +132,18 @@ async fn main() -> anyhow::Result<()> {
                     ])
                     .build(),
             );
-            let provider = provider_builder.build();
-            let tracer = provider.tracer(env!("CARGO_PKG_NAME"));
-            
-            let trace_filter = Targets::new()
-                .with_default(LevelFilter::OFF)
-                .with_target("tips_ingress_rpc", LevelFilter::TRACE);
+        let provider = provider_builder.build();
+        let tracer = provider.tracer(env!("CARGO_PKG_NAME"));
 
-            tracing::subscriber::set_global_default(
-                tracing_subscriber::registry().with(trace_filter).with(OpenTelemetryLayer::new(tracer)),
-            )?;
+        let trace_filter = Targets::new()
+            .with_default(LevelFilter::OFF)
+            .with_target(env!("CARGO_PKG_NAME"), LevelFilter::TRACE);
+
+        tracing::subscriber::set_global_default(
+            tracing_subscriber::registry()
+                .with(trace_filter)
+                .with(OpenTelemetryLayer::new(tracer)),
+        )?;
     }
 
     let provider: RootProvider<Optimism> = ProviderBuilder::new()

--- a/crates/ingress-writer/src/main.rs
+++ b/crates/ingress-writer/src/main.rs
@@ -35,6 +35,12 @@ struct Args {
 
     #[arg(long, env = "TIPS_INGRESS_WRITER_LOG_LEVEL", default_value = "info")]
     log_level: String,
+
+    #[arg(long, env = "TIPS_INGRESS_WRITER_TRACING_ENABLED", default_value = "false")]
+    tracing_enabled: bool,
+
+    #[arg(long, env = "TIPS_INGRESS_WRITER_TRACING_OTLP_ENDPOINT", default_value = "http://localhost:4317")]
+    tracing_otlp_endpoint: String,
 }
 
 /// IngressWriter consumes bundles sent from the Ingress service and writes them to the datastore
@@ -128,6 +134,14 @@ async fn main() -> Result<()> {
     tracing_subscriber::fmt()
         .with_env_filter(&args.log_level)
         .init();
+
+    if args.tracing_enabled {
+        init_tracing(
+            env!("CARGO_PKG_NAME").to_string(),
+            env!("CARGO_PKG_VERSION").to_string(),
+            args.tracing_otlp_endpoint,
+        )?;
+    }
 
     let mut config = ClientConfig::new();
     config

--- a/crates/maintenance/src/main.rs
+++ b/crates/maintenance/src/main.rs
@@ -38,6 +38,12 @@ struct Args {
 
     #[arg(long, env = "TIPS_MAINTENANCE_LOG_LEVEL", default_value = "info")]
     log_level: String,
+
+    #[arg(long, env = "TIPS_MAINTENANCE_TRACING_ENABLED", default_value = "false")]
+    tracing_enabled: bool,
+
+    #[arg(long, env = "TIPS_MAINTENANCE_TRACING_OTLP_ENDPOINT", default_value = "http://localhost:4317")]
+    tracing_otlp_endpoint: String,
 }
 
 #[tokio::main]
@@ -70,6 +76,14 @@ async fn main() -> Result<()> {
         .init();
 
     info!("Starting maintenance service");
+
+    if args.tracing_enabled {
+        init_tracing(
+            env!("CARGO_PKG_NAME").to_string(),
+            env!("CARGO_PKG_VERSION").to_string(),
+            args.tracing_otlp_endpoint,
+        )?;
+    }
 
     let provider: RootProvider<Optimism> = ProviderBuilder::new()
         .disable_recommended_fillers()

--- a/crates/tracing/Cargo.toml
+++ b/crates/tracing/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "tips-tracing"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+anyhow.workspace = true
+opentelemetry.workspace = true
+opentelemetry-otlp.workspace = true
+opentelemetry_sdk.workspace = true
+tracing.workspace = true
+tracing-opentelemetry.workspace = true
+tracing-subscriber.workspace = true

--- a/crates/tracing/src/lib.rs
+++ b/crates/tracing/src/lib.rs
@@ -1,0 +1,47 @@
+use anyhow::Context;
+use opentelemetry::{global, KeyValue};
+use opentelemetry_otlp::{SpanExporter, WithExportConfig};
+use opentelemetry_sdk::{propagation::TraceContextPropagator, trace::SdkTracerProvider, Resource};
+use tracing_opentelemetry::OpenTelemetryLayer;
+use tracing_subscriber::{filter::{LevelFilter, Targets}, layer::SubscriberExt};
+use opentelemetry::trace::TracerProvider;
+
+pub fn init_tracing(
+    service_name: String,
+    service_version: String,
+    otlp_endpoint: String,
+) -> anyhow::Result<()> {
+    global::set_text_map_propagator(TraceContextPropagator::new());
+
+    let otlp_exporter = SpanExporter::builder()
+        .with_tonic()
+        .with_endpoint(otlp_endpoint)
+        .build()
+        .context("Failed to create OTLP exporter")?;
+
+    let provider_builder = SdkTracerProvider::builder()
+        .with_batch_exporter(otlp_exporter)
+        .with_resource(
+            Resource::builder_empty()
+                .with_attributes([
+                    KeyValue::new("service.name", service_name.clone()),
+                    KeyValue::new("service.version", service_version),
+                ])
+                .build(),
+        );
+
+    let provider = provider_builder.build();
+    let tracer = provider.tracer(service_name.clone());
+
+    let trace_filter = Targets::new()
+        .with_default(LevelFilter::OFF)
+        .with_target(service_name, LevelFilter::TRACE);
+
+    tracing::subscriber::set_global_default(
+        tracing_subscriber::registry()
+            .with(trace_filter)
+            .with(OpenTelemetryLayer::new(tracer)),
+    )?;
+
+    Ok(())
+}


### PR DESCRIPTION
## Overview

Distributed tracing will let us visualize in a flamegraph format of where a txn spends the most time in TIPS. 

This would be particularly helpful in terms of optimizing certain TIPS components. 

## Resources

- https://www.datadoghq.com/knowledge-center/distributed-tracing/ 
- https://docs.datadoghq.com/tracing/glossary/
- https://www.datadoghq.com/blog/monitor-rust-otel/#traces-instrumenting-the-http-framework
- https://github.com/flashbots/rollup-boost/blob/08ebd3e75a8f4c7ebc12db13b042dee04e132c05/crates/rollup-boost/src/tracing.rs#L127

## Tests

- [ ] Pending after infra is setup 