### PR TITLE
ci: enforce clippy warnings to be same as locally

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,2 @@
+[target.'cfg(all())']
+rustflags = ["-D", "warnings"]

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -66,7 +66,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@5d458579430fc14a04a08a1e7d3694f545e91ce6 # stable
         with:
           components: clippy
-      - run: cargo clippy -- -D warnings
+      - run: cargo clippy
 
   build:
     name: Build


### PR DESCRIPTION
`cargo clippy -- -D warnings` locally captures errors like formatting but in the CI it seems to be ok

This PR makes it so that local and ci environments are producing the same results