### PR TITLE
feat: enable datadog apm tracing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6592,6 +6592,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "opentelemetry-appender-tracing"
+version = "0.31.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef6a1ac5ca3accf562b8c306fa8483c85f4390f768185ab775f242f7fe8fdcc2"
+dependencies = [
+ "opentelemetry 0.31.0",
+ "tracing",
+ "tracing-core",
+ "tracing-subscriber 0.3.20",
+]
+
+[[package]]
 name = "opentelemetry-datadog"
 version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -12673,6 +12685,7 @@ dependencies = [
  "op-alloy-network",
  "op-revm",
  "opentelemetry 0.31.0",
+ "opentelemetry-appender-tracing",
  "opentelemetry-datadog",
  "opentelemetry-otlp 0.31.0",
  "opentelemetry-semantic-conventions",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -86,3 +86,4 @@ tracing-opentelemetry = "0.32.0"
 reqwest = { version = "0.12", features = ["json"] }
 opentelemetry-datadog = { version = "0.19.0", features = ["reqwest-blocking-client", "reqwest-client"] }
 opentelemetry-semantic-conventions = { version = "0.31.0" }
+opentelemetry-appender-tracing = "0.31.1"

--- a/crates/ingress-rpc/Cargo.toml
+++ b/crates/ingress-rpc/Cargo.toml
@@ -42,3 +42,4 @@ tracing-opentelemetry.workspace = true
 reqwest.workspace = true
 opentelemetry-datadog = { workspace = true, features = ["reqwest-client", "agent-sampling"]}
 opentelemetry-semantic-conventions.workspace = true
+opentelemetry-appender-tracing.workspace = true


### PR DESCRIPTION
related: #22 , #29 

## Overview

Distributed tracing will let us visualize in a flamegraph format of where a txn spends the most time in TIPS. 

This would be particularly helpful in terms of optimizing certain TIPS components. 

## Resources

- https://www.datadoghq.com/knowledge-center/distributed-tracing/ 
- https://docs.datadoghq.com/tracing/glossary/
- https://www.datadoghq.com/blog/monitor-rust-otel/#traces-instrumenting-the-http-framework
- https://www.reddit.com/r/rust/comments/1dkxo6j/tracing_with_datadog/

## References

- https://github.com/flashbots/rollup-boost/blob/08ebd3e75a8f4c7ebc12db13b042dee04e132c05/crates/rollup-boost/src/tracing.rs#L127
- https://github.com/commonwarexyz/monorepo/blob/27e6f73fce91fc46ef7170e928cbcf96cc635fea/runtime/src/tokio/tracing.rs#L28
- https://github.com/open-telemetry/opentelemetry-rust-contrib/blob/main/opentelemetry-datadog/examples/agent_sampling.rs
- https://github.com/open-telemetry/opentelemetry-rust/blob/main/opentelemetry-otlp/examples/basic-otlp-http/src/main.rs

## TODOs

- [x] Pending after infra is setup 
- [ ] Be able to view trace spans in DataDog APM
- [ ] Add more traces for each service to demonstrate PoC