### PR TITLE
feat: add state root time to meter bundle response

### DIFF
--- a/crates/core/src/types.rs
+++ b/crates/core/src/types.rs
@@ -156,6 +156,7 @@ pub struct MeterBundleResponse {
     pub state_block_number: u64,
     pub total_gas_used: u64,
     pub total_execution_time_us: u128,
+    pub state_root_time_us: u128,
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Add state_root_time_us field to MeterBundleResponse to expose state root calculation time in the metering RPC response. This enables clients to track the performance of state root calculations separately from total execution time.