### PR TITLE
chroe: add `Clone` to `BundleData` to fix error on op-rbuilder

### DIFF
--- a/crates/bundle-pool/src/pool.rs
+++ b/crates/bundle-pool/src/pool.rs
@@ -42,6 +42,7 @@ pub trait BundleStore {
     fn on_new_block(&mut self, number: u64, hash: TxHash);
 }
 
+#[derive(Clone)]
 struct BundleData {
     flashblocks_in_block: HashMap<u64, Vec<ProcessedBundle>>,
     bundles: HashMap<Uuid, AcceptedBundle>,


### PR DESCRIPTION
From: https://github.com/base/op-rbuilder/pull/17/

`op-rbuilder` was complaining that `InMemoryBundlePool` didn't fully implement `Clone`