### PR TITLE
chore: update setup md steps

### DIFF
--- a/SETUP.md
+++ b/SETUP.md
@@ -27,7 +27,6 @@ git checkout danyal/base-overlay
 # Clone op-rbuilder in a separate directory
 git clone https://github.com/base/op-rbuilder.git
 cd op-rbuilder
-git checkout tips-prototype
 ```
 
 ## Step 2: Start TIPS Infrastructure


### PR DESCRIPTION
No need to check out tips-prototype anymore for the op-r builder — everything’s been merged upstream. Just keeping the docs consistent so nobody ends up stuck on an old branch. 🙏 