### PR TITLE
wip feat: kafka guarantee ordering

### DIFF
--- a/crates/audit/src/types.rs
+++ b/crates/audit/src/types.rs
@@ -90,17 +90,6 @@ impl BundleEvent {
     }
 
     pub fn generate_event_key(&self) -> String {
-        match self {
-            BundleEvent::BlockIncluded {
-                bundle_id,
-                block_hash,
-                ..
-            } => {
-                format!("{bundle_id}-{block_hash}")
-            }
-            _ => {
-                format!("{}-{}", self.bundle_id(), Uuid::new_v4())
-            }
-        }
+        self.bundle_id().to_string()
     }
 }


### PR DESCRIPTION
## Overview

Kafka guarantees ordering within a partition, but not across a topic. We would want everything with the same key to go to the same partition. That is, the same `bundle_id` for bundle events to the same partition.

In our current setup, the key format changes depending if it's `BlockIncluded` or not (i.e., we can have `098765-0xdeadbeef` or `098765-123456`. For the same BundleEvent with a bundle_id of `098765`, this would be sent to two different partitions. 

As a side note, we don't need to configure the partition to send to because looking at the source code, the underlying Kafka implementation is based on the hash of the key (see the notes from BaseProducer implementation):

```
    /// When no partition is specified the underlying Kafka library picks a
    /// partition based on a hash of the key. If no key is specified, a random
    /// partition will be used. To correctly handle errors, the delivery
    /// callback should be implemented.
```