### PR TITLE
chore: add GHA for stale PRs/issues

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -29,4 +29,4 @@ jobs:
           close-issue-message: 'This issue was closed because it has been inactive for 5 days since being marked as stale.'
           close-pr-message: 'This pull request was closed because it has been inactive for 5 days since being marked as stale.'
           exempt-issue-labels: keep-open
-          exempt-issue-labels: keep-open
+          exempt-pr-labels: keep-open


### PR DESCRIPTION
### Description
Setup a periodic Github Action to auto-close PR's and issues that have had no activity in a while. You can keep these open by apply the tag `keep-open`