### PR TITLE
chore: have shadow mode

### DIFF
--- a/crates/ingress-rpc/src/lib.rs
+++ b/crates/ingress-rpc/src/lib.rs
@@ -20,6 +20,7 @@ pub enum TxSubmissionMethod {
     Mempool,
     Kafka,
     MempoolAndKafka,
+    None,
 }
 
 impl FromStr for TxSubmissionMethod {
@@ -30,8 +31,9 @@ impl FromStr for TxSubmissionMethod {
             "mempool" => Ok(TxSubmissionMethod::Mempool),
             "kafka" => Ok(TxSubmissionMethod::Kafka),
             "mempool,kafka" | "kafka,mempool" => Ok(TxSubmissionMethod::MempoolAndKafka),
+            "none" => Ok(TxSubmissionMethod::None),
             _ => Err(format!(
-                "Invalid submission method: '{s}'. Valid options: mempool, kafka, mempool,kafka, kafka,mempool"
+                "Invalid submission method: '{s}'. Valid options: mempool, kafka, mempool,kafka, kafka,mempool, none"
             )),
         }
     }


### PR DESCRIPTION
shadow mode is where the TxSubmissionMethod is None

basically if we have `TxSubmissionMethod::None`, then this will skip over `send_to_mempool` and `send_to_kafka` checks as it will be false in `service.rs`

we will still do the forward to provider and send an audit event