### PR TITLE
fix(ui): handle undefined values in BigInt formatting functions

### DIFF
--- a/ui/src/app/bundles/[uuid]/page.tsx
+++ b/ui/src/app/bundles/[uuid]/page.tsx
@@ -19,7 +19,8 @@ function formatBigInt(value: bigint, decimals: number, scale: bigint): string {
   return `${whole}.${frac.toString().padStart(decimals, "0")}`;
 }
 
-function formatHexValue(hex: string): string {
+function formatHexValue(hex: string | undefined): string {
+  if (!hex) return "—";
   const value = BigInt(hex);
   if (value >= WEI_PER_ETH / 10000n) {
     return `${formatBigInt(value, 6, WEI_PER_ETH)} ETH`;
@@ -30,7 +31,8 @@ function formatHexValue(hex: string): string {
   return `${value.toString()} Wei`;
 }
 
-function formatGasPrice(hex: string): string {
+function formatGasPrice(hex: string | undefined): string {
+  if (!hex) return "—";
   const value = BigInt(hex);
   return `${formatBigInt(value, 2, WEI_PER_GWEI)} Gwei`;
 }


### PR DESCRIPTION
### Description
Add null checks to formatHexValue() and formatGasPrice() to prevent "Cannot convert undefined to a BigInt" error when viewing bundles with missing meter fields.