### PR TITLE
fix(ui): remove bundle and reverting tags from UI

### DIFF
--- a/ui/src/app/block/[hash]/page.tsx
+++ b/ui/src/app/block/[hash]/page.tsx
@@ -128,11 +128,6 @@ function TransactionRow({
               {tx.hash}
             </span>
           )}
-          {hasBundle && (
-            <span className="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-blue-100 text-blue-700">
-              Bundle
-            </span>
-          )}
         </div>
         <div className="text-xs text-gray-500 mt-0.5">
           {tx.from.slice(0, 6)}...{tx.from.slice(-4)}

--- a/ui/src/app/bundles/[uuid]/page.tsx
+++ b/ui/src/app/bundles/[uuid]/page.tsx
@@ -156,11 +156,9 @@ function Card({
 function TransactionDetails({
   tx,
   index,
-  isReverting,
 }: {
   tx: BundleTransaction;
   index: number;
-  isReverting: boolean;
 }) {
   const [expanded, setExpanded] = useState(index === 0);
 
@@ -180,7 +178,6 @@ function TransactionDetails({
               <span className="font-mono text-sm text-gray-900">
                 {tx.hash.slice(0, 10)}...{tx.hash.slice(-8)}
               </span>
-              {isReverting && <Badge variant="warning">Reverting</Badge>}
             </div>
             <div className="text-xs text-gray-500 mt-0.5">
               {tx.signer.slice(0, 6)}...{tx.signer.slice(-4)} →{" "}
@@ -480,7 +477,6 @@ export default function BundlePage({ params }: PageProps) {
     .filter((e) => e.data?.bundle)
     .map((e) => e.data.bundle)
     .pop();
-  const revertingHashes = new Set(latestBundle?.reverting_tx_hashes || []);
 
   return (
     <div className="min-h-screen bg-gray-50">
@@ -558,12 +554,7 @@ export default function BundlePage({ params }: PageProps) {
               <SectionTitle>Transactions</SectionTitle>
               <div className="space-y-3">
                 {latestBundle.txs.map((tx, index) => (
-                  <TransactionDetails
-                    key={tx.hash}
-                    tx={tx}
-                    index={index}
-                    isReverting={revertingHashes.has(tx.hash)}
-                  />
+                  <TransactionDetails key={tx.hash} tx={tx} index={index} />
                 ))}
               </div>
             </section>


### PR DESCRIPTION
## Description
Remove these tags as they're confusing (no bundles etc).

- Remove the "Bundle" tag from block transaction rows
- Remove the "Reverting" badge from bundle transaction details