### PR TITLE
chore(workspace): Touchup Justfile

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -1,44 +1,47 @@
-### DEVELOPMENT COMMANDS ###
+set positional-arguments
+
+alias f := fix
+alias c := ci
+
+# Default to display help menu
+default:
+    @just --list
+
+# Runs all ci checks
 ci:
-    # Rust
     cargo fmt --all -- --check
     cargo clippy -- -D warnings
     cargo build
     cargo test
-    # UI
-    cd ui && npm run lint
+    cd ui && npx --yes @biomejs/biome check .
     cd ui && npm run build
 
+# Fixes formatting and clippy issues
 fix:
-    # Rust
     cargo fmt --all
     cargo clippy --fix --allow-dirty --allow-staged
-    # UI
-    cd ui && npx biome check --write --unsafe
+    cd ui && npx --yes @biomejs/biome check --write --unsafe .
 
-sync: deps-reset
-    ###   ENV    ###
-    just sync-env
-    ###    REFORMAT   ###
-    just fix
+# Resets dependencies and reformats code
+sync: deps-reset sync-env fix
 
+# Copies environment templates and adapts for docker
 sync-env:
     cp .env.example .env
     cp .env.example ./ui/.env
     cp .env.example .env.docker
-    # Change kafka ports
     sed -i '' 's/localhost:9092/host.docker.internal:9094/g' ./.env.docker
-    # Change other dependencies
     sed -i '' 's/localhost/host.docker.internal/g' ./.env.docker
 
+# Stops and removes all docker containers and data
 stop-all:
     export COMPOSE_FILE=docker-compose.yml:docker-compose.tips.yml && docker compose down && docker compose rm && rm -rf data/
 
-# Start every service running in docker, useful for demos
+# Starts all services in docker, useful for demos
 start-all: stop-all
     export COMPOSE_FILE=docker-compose.yml:docker-compose.tips.yml && mkdir -p data/kafka data/minio && docker compose build && docker compose up -d
 
-# Start every service in docker, except the one you're currently working on. e.g. just start-except ui ingress-rpc
+# Starts docker services except specified ones, e.g. just start-except ui ingress-rpc
 start-except programs: stop-all
     #!/bin/bash
     all_services=(kafka kafka-setup minio minio-setup ingress-rpc audit ui)
@@ -61,25 +64,31 @@ start-except programs: stop-all
 
     export COMPOSE_FILE=docker-compose.yml:docker-compose.tips.yml && mkdir -p data/kafka data/minio && docker compose build && docker compose up -d ${result_services[@]}
 
-### RUN SERVICES ###
+# Resets docker dependencies with clean data
 deps-reset:
     COMPOSE_FILE=docker-compose.yml:docker-compose.tips.yml docker compose down && docker compose rm && rm -rf data/ && mkdir -p data/kafka data/minio && docker compose up -d
 
+# Restarts docker dependencies without data reset
 deps:
     COMPOSE_FILE=docker-compose.yml:docker-compose.tips.yml docker compose down && docker compose rm && docker compose up -d
 
+# Runs the tips-audit service
 audit:
     cargo run --bin tips-audit
 
+# Runs the tips-ingress-rpc service
 ingress-rpc:
     cargo run --bin tips-ingress-rpc
 
+# Runs the tips-maintenance service
 maintenance:
     cargo run --bin tips-maintenance
 
+# Runs the tips-ingress-writer service
 ingress-writer:
     cargo run --bin tips-ingress-writer
 
+# Starts the UI development server
 ui:
     cd ui && yarn dev
 
@@ -88,6 +97,13 @@ validator_url := "http://localhost:8549"
 builder_url := "http://localhost:2222"
 ingress_url := "http://localhost:8080"
 
+sender := "0x70997970C51812dc3A010C7d01b50e0d17dc79C8"
+sender_key := "0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d"
+
+backrunner := "0x3C44CdDdB6a900fa2b585dd299e03d12FA4293BC"
+backrunner_key := "0x5de4111afa1a4b94908f83103eb1f1706367c2e68ca870fc3fb9a804cdab365a"
+
+# Queries block numbers from sequencer, validator, and builder
 get-blocks:
     echo "Sequencer"
     cast bn -r {{ sequencer_url }}
@@ -96,12 +112,7 @@ get-blocks:
     echo "Builder"
     cast bn -r {{ builder_url }}
 
-sender := "0x70997970C51812dc3A010C7d01b50e0d17dc79C8"
-sender_key := "0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d"
-
-backrunner := "0x3C44CdDdB6a900fa2b585dd299e03d12FA4293BC"
-backrunner_key := "0x5de4111afa1a4b94908f83103eb1f1706367c2e68ca870fc3fb9a804cdab365a"
-
+# Sends a test transaction through the ingress endpoint
 send-txn:
     #!/usr/bin/env bash
     set -euxo pipefail
@@ -112,6 +123,7 @@ send-txn:
     cast receipt $hash -r {{ sequencer_url }} | grep status
     cast receipt $hash -r {{ builder_url }} | grep status
 
+# Sends a transaction with a backrun bundle
 send-txn-with-backrun:
     #!/usr/bin/env bash
     set -euxo pipefail
@@ -176,6 +188,7 @@ send-txn-with-backrun:
     echo "=== Backrun transaction (from backrunner) ==="
     cast receipt $backrun_hash_computed -r {{ sequencer_url }} | grep -E "(status|blockNumber|transactionIndex)" || echo "Backrun tx not found yet"
 
+# Runs integration tests with infrastructure checks
 e2e:
     #!/bin/bash
     if ! INTEGRATION_TESTS=1 cargo test --package tips-system-tests --test integration_tests; then


### PR DESCRIPTION
### Description

Small PR to touchup the `Justfile`.

#### Changeset

- Default `just` command now lists available targets rather than running the `ci` target.
- Fixes `just ci` to pass on fresh repository clone by gracefully running `npm install` which installs custom binaries.