### PR TITLE
chore(workspace): Workspace Manifest Updates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -444,7 +444,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cf1398cb33aacb139a960fa3d8cf8b1202079f320e77e952a0b95967bf7a9f"
 dependencies = [
  "alloy-primitives",
- "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
  "alloy-serde",
  "serde",
@@ -487,8 +486,6 @@ dependencies = [
  "derive_more",
  "ethereum_ssz",
  "ethereum_ssz_derive",
- "jsonwebtoken",
- "rand 0.8.5",
  "serde",
  "strum",
 ]
@@ -549,7 +546,7 @@ dependencies = [
  "async-trait",
  "auto_impl",
  "either",
- "elliptic-curve 0.13.8",
+ "elliptic-curve",
  "k256",
  "thiserror 2.0.17",
 ]
@@ -1174,8 +1171,6 @@ checksum = "96571e6996817bf3d58f6b569e4b9fd2e9d2fcf9f7424eed07b2ce9bb87535e5"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
- "aws-sdk-sso",
- "aws-sdk-ssooidc",
  "aws-sdk-sts",
  "aws-smithy-async",
  "aws-smithy-http",
@@ -1186,14 +1181,11 @@ dependencies = [
  "aws-types",
  "bytes",
  "fastrand",
- "hex",
  "http 1.4.0",
- "ring",
  "time",
  "tokio",
  "tracing",
  "url",
- "zeroize",
 ]
 
 [[package]]
@@ -1290,50 +1282,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "aws-sdk-sso"
-version = "1.91.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ee6402a36f27b52fe67661c6732d684b2635152b676aa2babbfb5204f99115d"
-dependencies = [
- "aws-credential-types",
- "aws-runtime",
- "aws-smithy-async",
- "aws-smithy-http",
- "aws-smithy-json",
- "aws-smithy-runtime",
- "aws-smithy-runtime-api",
- "aws-smithy-types",
- "aws-types",
- "bytes",
- "fastrand",
- "http 0.2.12",
- "regex-lite",
- "tracing",
-]
-
-[[package]]
-name = "aws-sdk-ssooidc"
-version = "1.93.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a45a7f750bbd170ee3677671ad782d90b894548f4e4ae168302c57ec9de5cb3e"
-dependencies = [
- "aws-credential-types",
- "aws-runtime",
- "aws-smithy-async",
- "aws-smithy-http",
- "aws-smithy-json",
- "aws-smithy-runtime",
- "aws-smithy-runtime-api",
- "aws-smithy-types",
- "aws-types",
- "bytes",
- "fastrand",
- "http 0.2.12",
- "regex-lite",
- "tracing",
-]
-
-[[package]]
 name = "aws-sdk-sts"
 version = "1.95.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1368,20 +1316,15 @@ dependencies = [
  "aws-smithy-runtime-api",
  "aws-smithy-types",
  "bytes",
- "crypto-bigint 0.5.5",
  "form_urlencoded",
  "hex",
  "hmac",
  "http 0.2.12",
  "http 1.4.0",
- "p256 0.11.1",
  "percent-encoding",
- "ring",
  "sha2",
- "subtle",
  "time",
  "tracing",
- "zeroize",
 ]
 
 [[package]]
@@ -1604,7 +1547,6 @@ checksum = "8b52af3cb4058c895d37317bb27508dccc8e5f2d39454016b297bf4a400597b8"
 dependencies = [
  "axum-core",
  "bytes",
- "form_urlencoded",
  "futures-util",
  "http 1.4.0",
  "http-body 1.0.1",
@@ -1620,13 +1562,11 @@ dependencies = [
  "serde_core",
  "serde_json",
  "serde_path_to_error",
- "serde_urlencoded",
  "sync_wrapper",
  "tokio",
  "tower",
  "tower-layer",
  "tower-service",
- "tracing",
 ]
 
 [[package]]
@@ -1645,7 +1585,6 @@ dependencies = [
  "sync_wrapper",
  "tower-layer",
  "tower-service",
- "tracing",
 ]
 
 [[package]]
@@ -1661,15 +1600,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cffb0e931875b666fc4fcb20fee52e9bbd1ef836fd9e9e04ec21555f9f85f7ef"
 dependencies = [
  "fastrand",
- "gloo-timers",
  "tokio",
 ]
-
-[[package]]
-name = "base16ct"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "349a06037c7bf932dd7e7d1f653678b2038b9ad46a74102f1fc7bd7872678cce"
 
 [[package]]
 name = "base16ct"
@@ -1704,24 +1636,6 @@ name = "base64ct"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e050f626429857a27ddccb31e0aca21356bfa709c04041aefddac081a8f068a"
-
-[[package]]
-name = "bindgen"
-version = "0.72.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
-dependencies = [
- "bitflags 2.10.0",
- "cexpr",
- "clang-sys",
- "itertools 0.13.0",
- "proc-macro2",
- "quote",
- "regex",
- "rustc-hash",
- "shlex",
- "syn 2.0.111",
-]
 
 [[package]]
 name = "bit-set"
@@ -1947,15 +1861,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
 
 [[package]]
-name = "cexpr"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
-dependencies = [
- "nom",
-]
-
-[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1977,17 +1882,6 @@ dependencies = [
  "num-traits",
  "serde",
  "windows-link",
-]
-
-[[package]]
-name = "clang-sys"
-version = "1.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
-dependencies = [
- "glob",
- "libc",
- "libloading",
 ]
 
 [[package]]
@@ -2226,18 +2120,6 @@ checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-bigint"
-version = "0.4.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef2b4b23cddf68b89b8f8069890e8c270d54e2d5fe1b143820234805e4cb17ef"
-dependencies = [
- "generic-array",
- "rand_core 0.6.4",
- "subtle",
- "zeroize",
-]
-
-[[package]]
-name = "crypto-bigint"
 version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
@@ -2360,16 +2242,6 @@ name = "deadpool-runtime"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "092966b41edc516079bdf31ec78a2e0588d1d0c08f78b91d8307215928642b2b"
-
-[[package]]
-name = "der"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1a467a65c5e759bce6e65eaf91cc29f466cdc57cb65777bd646872a8a1fd4de"
-dependencies = [
- "const-oid",
- "zeroize",
-]
 
 [[package]]
 name = "der"
@@ -2505,29 +2377,17 @@ checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "ecdsa"
-version = "0.14.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "413301934810f597c1d19ca71c8710e99a3f1ba28a0d2ebc01551a2daeea3c5c"
-dependencies = [
- "der 0.6.1",
- "elliptic-curve 0.12.3",
- "rfc6979 0.3.1",
- "signature 1.6.4",
-]
-
-[[package]]
-name = "ecdsa"
 version = "0.16.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
 dependencies = [
- "der 0.7.10",
+ "der",
  "digest 0.10.7",
- "elliptic-curve 0.13.8",
- "rfc6979 0.4.0",
+ "elliptic-curve",
+ "rfc6979",
  "serdect",
- "signature 2.2.0",
- "spki 0.7.3",
+ "signature",
+ "spki",
 ]
 
 [[package]]
@@ -2553,39 +2413,19 @@ dependencies = [
 
 [[package]]
 name = "elliptic-curve"
-version = "0.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7bb888ab5300a19b8e5bceef25ac745ad065f3c9f7efc6de1b91958110891d3"
-dependencies = [
- "base16ct 0.1.1",
- "crypto-bigint 0.4.9",
- "der 0.6.1",
- "digest 0.10.7",
- "ff 0.12.1",
- "generic-array",
- "group 0.12.1",
- "pkcs8 0.9.0",
- "rand_core 0.6.4",
- "sec1 0.3.0",
- "subtle",
- "zeroize",
-]
-
-[[package]]
-name = "elliptic-curve"
 version = "0.13.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
 dependencies = [
- "base16ct 0.2.0",
- "crypto-bigint 0.5.5",
+ "base16ct",
+ "crypto-bigint",
  "digest 0.10.7",
- "ff 0.13.1",
+ "ff",
  "generic-array",
- "group 0.13.0",
- "pkcs8 0.10.2",
+ "group",
+ "pkcs8",
  "rand_core 0.6.4",
- "sec1 0.7.3",
+ "sec1",
  "serdect",
  "subtle",
  "zeroize",
@@ -2736,16 +2576,6 @@ dependencies = [
  "arrayvec",
  "auto_impl",
  "bytes",
-]
-
-[[package]]
-name = "ff"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d013fc25338cc558c5c2cfbad646908fb23591e2404481826742b651c9af7160"
-dependencies = [
- "rand_core 0.6.4",
- "subtle",
 ]
 
 [[package]]
@@ -2988,18 +2818,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
-name = "gloo-timers"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbb143cf96099802033e0d4f4963b19fd2e0b728bcf076cd9cf7f6634f092994"
-dependencies = [
- "futures-channel",
- "futures-core",
- "js-sys",
- "wasm-bindgen",
-]
-
-[[package]]
 name = "gmp-mpfr-sys"
 version = "1.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3011,22 +2829,11 @@ dependencies = [
 
 [[package]]
 name = "group"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dfbfb3a6cfbd390d5c9564ab283a0349b9b9fcd46a706c1eb10e0db70bfbac7"
-dependencies = [
- "ff 0.12.1",
- "rand_core 0.6.4",
- "subtle",
-]
-
-[[package]]
-name = "group"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
 dependencies = [
- "ff 0.13.1",
+ "ff",
  "rand_core 0.6.4",
  "subtle",
 ]
@@ -3793,29 +3600,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "jsonwebtoken"
-version = "9.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a87cc7a48537badeae96744432de36f4be2b4a34a05a5ef32e9dd8a1c169dde"
-dependencies = [
- "base64 0.22.1",
- "js-sys",
- "pem",
- "ring",
- "serde",
- "serde_json",
- "simple_asn1",
-]
-
-[[package]]
 name = "k256"
 version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6e3919bbaa2945715f0bb6d3934a173d1e9a59ac23767fbaaef277265a7411b"
 dependencies = [
  "cfg-if",
- "ecdsa 0.16.9",
- "elliptic-curve 0.13.8",
+ "ecdsa",
+ "elliptic-curve",
  "once_cell",
  "serdect",
  "sha2",
@@ -3851,16 +3643,6 @@ name = "libc"
 version = "0.2.178"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37c93d8daa9d8a012fd8ab92f088405fb202ea0b6ab73ee2482ae66af4f42091"
-
-[[package]]
-name = "libloading"
-version = "0.8.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
-dependencies = [
- "cfg-if",
- "windows-link",
-]
 
 [[package]]
 name = "libm"
@@ -4015,7 +3797,6 @@ dependencies = [
  "base64 0.22.1",
  "http-body-util",
  "hyper 1.8.1",
- "hyper-rustls 0.27.7",
  "hyper-util",
  "indexmap 2.12.1",
  "ipnet",
@@ -4048,12 +3829,6 @@ name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
-
-[[package]]
-name = "minimal-lexical"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
@@ -4140,22 +3915,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "nom"
-version = "7.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
-dependencies = [
- "memchr",
- "minimal-lexical",
-]
-
-[[package]]
 name = "nu-ansi-term"
 version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4428,15 +4193,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
 
 [[package]]
-name = "openssl-src"
-version = "300.5.4+3.5.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a507b3792995dae9b0df8a1c1e3771e8418b7c2d9f0baeba32e6fe8b06c7cb72"
-dependencies = [
- "cc",
-]
-
-[[package]]
 name = "openssl-sys"
 version = "0.9.111"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4444,7 +4200,6 @@ checksum = "82cab2d520aa75e3c58898289429321eb788c3106963d0dc886ec7a5f4adc321"
 dependencies = [
  "cc",
  "libc",
- "openssl-src",
  "pkg-config",
  "vcpkg",
 ]
@@ -4457,23 +4212,12 @@ checksum = "1a80800c0488c3a21695ea981a54918fbb37abf04f4d0720c453632255e2ff0e"
 
 [[package]]
 name = "p256"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51f44edd08f51e2ade572f141051021c5af22677e42b7dd28a88155151c33594"
-dependencies = [
- "ecdsa 0.14.8",
- "elliptic-curve 0.12.3",
- "sha2",
-]
-
-[[package]]
-name = "p256"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c9863ad85fa8f4460f9c48cb909d38a0d689dba1f6f6988a5e3e0d31071bcd4b"
 dependencies = [
- "ecdsa 0.16.9",
- "elliptic-curve 0.13.8",
+ "ecdsa",
+ "elliptic-curve",
  "primeorder",
  "sha2",
 ]
@@ -4559,16 +4303,6 @@ name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
-
-[[package]]
-name = "pem"
-version = "3.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
-dependencies = [
- "base64 0.22.1",
- "serde_core",
-]
 
 [[package]]
 name = "percent-encoding"
@@ -4663,22 +4397,12 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pkcs8"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9eca2c590a5f85da82668fa685c09ce2888b9430e83299debf1f34b65fd4a4ba"
-dependencies = [
- "der 0.6.1",
- "spki 0.6.0",
-]
-
-[[package]]
-name = "pkcs8"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
 dependencies = [
- "der 0.7.10",
- "spki 0.7.3",
+ "der",
+ "spki",
 ]
 
 [[package]]
@@ -4749,7 +4473,7 @@ version = "0.13.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "353e1ca18966c16d9deb1c69278edbc5f194139612772bd9537af60ac231e1e6"
 dependencies = [
- "elliptic-curve 0.13.8",
+ "elliptic-curve",
 ]
 
 [[package]]
@@ -5065,9 +4789,7 @@ dependencies = [
  "libc",
  "libz-sys",
  "num_enum",
- "openssl-sys",
  "pkg-config",
- "zstd-sys",
 ]
 
 [[package]]
@@ -6130,7 +5852,7 @@ dependencies = [
  "c-kzg",
  "cfg-if",
  "k256",
- "p256 0.13.2",
+ "p256",
  "revm-primitives",
  "ripemd",
  "rug",
@@ -6160,17 +5882,6 @@ dependencies = [
  "revm-bytecode",
  "revm-primitives",
  "serde",
-]
-
-[[package]]
-name = "rfc6979"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7743f17af12fa0b03b803ba12cd6a8d9483a587e89c69445e3909655c0b9fabb"
-dependencies = [
- "crypto-bigint 0.4.9",
- "hmac",
- "zeroize",
 ]
 
 [[package]]
@@ -6532,28 +6243,14 @@ checksum = "490dcfcbfef26be6800d11870ff2df8774fa6e86d047e3e8c8a76b25655e41ca"
 
 [[package]]
 name = "sec1"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3be24c1842290c45df0a7bf069e0c268a747ad05a192f2fd7dcfdbc1cba40928"
-dependencies = [
- "base16ct 0.1.1",
- "der 0.6.1",
- "generic-array",
- "pkcs8 0.9.0",
- "subtle",
- "zeroize",
-]
-
-[[package]]
-name = "sec1"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
 dependencies = [
- "base16ct 0.2.0",
- "der 0.7.10",
+ "base16ct",
+ "der",
  "generic-array",
- "pkcs8 0.10.2",
+ "pkcs8",
  "serdect",
  "subtle",
  "zeroize",
@@ -6775,7 +6472,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a84f14a19e9a014bb9f4512488d9829a68e04ecabffb0f9904cd1ace94598177"
 dependencies = [
- "base16ct 0.2.0",
+ "base16ct",
  "serde",
 ]
 
@@ -6872,34 +6569,12 @@ dependencies = [
 
 [[package]]
 name = "signature"
-version = "1.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74233d3b3b2f6d4b006dc19dee745e73e2a6bfb6f93607cd3b02bd5b00797d7c"
-dependencies = [
- "digest 0.10.7",
- "rand_core 0.6.4",
-]
-
-[[package]]
-name = "signature"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
  "digest 0.10.7",
  "rand_core 0.6.4",
-]
-
-[[package]]
-name = "simple_asn1"
-version = "0.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "297f631f50729c8c99b84667867963997ec0b50f32b2a7dbcab828ef0541e8bb"
-dependencies = [
- "num-bigint",
- "num-traits",
- "thiserror 2.0.17",
- "time",
 ]
 
 [[package]]
@@ -6973,22 +6648,12 @@ dependencies = [
 
 [[package]]
 name = "spki"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67cf02bbac7a337dc36e4f5a693db6c21e7863f45070f7064577eb4367a3212b"
-dependencies = [
- "base64ct",
- "der 0.6.1",
-]
-
-[[package]]
-name = "spki"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
 dependencies = [
  "base64ct",
- "der 0.7.10",
+ "der",
 ]
 
 [[package]]
@@ -7589,7 +7254,6 @@ dependencies = [
  "tokio",
  "tower-layer",
  "tower-service",
- "tracing",
 ]
 
 [[package]]
@@ -7628,7 +7292,6 @@ version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
- "log",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
@@ -7666,17 +7329,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tracing-log"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
-dependencies = [
- "log",
- "once_cell",
- "tracing-core",
-]
-
-[[package]]
 name = "tracing-serde"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7708,11 +7360,9 @@ dependencies = [
  "serde",
  "serde_json",
  "sharded-slab",
- "smallvec",
  "thread_local",
  "tracing",
  "tracing-core",
- "tracing-log",
  "tracing-serde",
 ]
 
@@ -8609,7 +8259,6 @@ version = "2.0.16+zstd.1.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
 dependencies = [
- "bindgen",
  "cc",
  "pkg-config",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,68 +10,89 @@ repository = "https://github.com/base/tips"
 members = ["crates/audit", "crates/ingress-rpc", "crates/core", "crates/account-abstraction-core", "crates/system-tests"]
 resolver = "2"
 
+[workspace.lints.rust]
+missing-debug-implementations = "warn"
+missing-docs = "warn"
+unreachable-pub = "warn"
+unused-must-use = "deny"
+rust-2018-idioms = "deny"
+unnameable-types = "warn"
+
+[workspace.lints.rustdoc]
+all = "warn"
+
+[workspace.lints.clippy]
+all = { level = "warn", priority = -1 }
+missing-const-for-fn = "warn"
+use-self = "warn"
+option-if-let-else = "warn"
+redundant-clone = "warn"
+
 [workspace.dependencies]
-tips-audit = { path = "crates/audit" }
+# local
 tips-core = { path = "crates/core" }
+tips-audit = { path = "crates/audit" }
 tips-system-tests = { path = "crates/system-tests" }
 account-abstraction-core = { path = "crates/account-abstraction-core" }
 
-# Reth
+# reth
 reth = { git = "https://github.com/paradigmxyz/reth", tag = "v1.9.3" }
-reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", tag = "v1.9.3" }
 reth-optimism-evm = { git = "https://github.com/paradigmxyz/reth", tag = "v1.9.3" }
+reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", tag = "v1.9.3" }
+
+# revm
+op-revm = { version = "12.0.0", default-features = false }
+revm-context-interface = { version = "12.0.0", default-features = false }
 
 # alloy
-alloy-primitives = { version = "1.4.1", default-features = false, features = [
-    "map-foldhash",
-    "serde",
-] }
-alloy-consensus = { version = "1.0.41" }
-alloy-provider = { version = "1.0.41" }
-alloy-rpc-types = "1.1.2"
-alloy-signer = { version = "1.0.41" }
-alloy-network = { version = "1.0.41" }
-alloy-serde = "1.0.41"
+alloy-serde = { version = "1.0.41", default-features = false }
+alloy-signer = { version = "1.0.41", default-features = false }
+alloy-network = { version = "1.0.41", default-features = false }
+alloy-provider = { version = "1.0.41", default-features = false }
+alloy-consensus = { version = "1.0.41", default-features = false }
 alloy-sol-types = { version = "1.4.1", default-features = false }
+alloy-rpc-types = { version = "1.1.2", default-features = false }
+alloy-primitives = { version = "1.4.1", default-features = false }
+alloy-signer-local = { version = "1.0.41", default-features = false }
 
 # op-alloy
+op-alloy-flz = { version = "0.13.1", default-features = false }
 op-alloy-network = { version = "0.22.0", default-features = false }
-op-alloy-consensus = { version = "0.22.0", features = ["k256", "serde"] }
-op-alloy-rpc-types = { version = "0.22.0", default-features = true}
-op-alloy-flz = {  version = "0.13.1" }
+op-alloy-rpc-types = { version = "0.22.0", default-features = false }
+op-alloy-consensus = { version = "0.22.0", default-features = false }
 
-tokio = { version = "1.47.1", features = ["full"] }
-tracing = "0.1.41"
-tracing-subscriber = { version = "0.3.20", features = ["env-filter", "json"] }
-anyhow = "1.0.99"
-clap = { version = "4.5.47", features = ["derive", "env"] }
-url = "2.5.7"
-uuid = { version = "1.18.1", features = ["v4", "serde"] }
-serde = { version = "1.0.219", features = ["derive"] }
+# tokio
+tokio = { version = "1.47.1", default-features = false }
+
+# async
 async-trait = "0.1.89"
-serde_json = "1.0.143"
-dotenvy = "0.15.7"
-testcontainers = { version = "0.23.1", features = ["blocking"] }
-testcontainers-modules = { version = "0.11.2", features = ["postgres", "kafka", "minio"] }
-jsonrpsee = { version = "0.26.0", features = ["server", "macros"] }
-chrono = { version = "0.4.42", features = ["serde"] }
-wiremock = "0.6.2"
-axum = "0.8.3"
 
-# Kafka and S3 dependencies
-rdkafka = { version = "0.37.0", features = ["zstd", "ssl-vendored"] }
-aws-config = "1.1.7"
-aws-sdk-s3 = "1.106.0"
-aws-credential-types = "1.1.7"
-bytes = { version = "1.8.0", features = ["serde"] }
+# rpc
+jsonrpsee = { version = "0.26.0", default-features = false }
 
-# tips-ingress
-backon = "1.5.2"
-op-revm = { version = "12.0.0", default-features = false }
-revm-context-interface = "12.0.0"
-alloy-signer-local = "1.0.41"
+# kafka and s3
+bytes = { version = "1.8.0", default-features = false }
+rdkafka = { version = "0.37.0", default-features = false }
+aws-config = { version = "1.1.7", default-features = false }
+aws-sdk-s3 = { version = "1.106.0", default-features = false }
+aws-credential-types = { version = "1.1.7", default-features = false }
 
-# Misc
-metrics = "0.24.1"
-metrics-derive = "0.1"
-metrics-exporter-prometheus = { version = "0.17.0", features = ["http-listener"]}
+# misc
+url = { version = "2.5.7", default-features = false }
+axum = { version = "0.8.3", default-features = false }
+serde = { version = "1.0.219", default-features = false }
+uuid = { version = "1.18.1", default-features = false }
+clap = { version = "4.5.47", default-features = false }
+backon = { version = "1.5.2", default-features = false }
+chrono = { version = "0.4.42", default-features = false }
+anyhow = { version = "1.0.99", default-features = false }
+tracing = { version = "0.1.41", default-features = false }
+wiremock = { version = "0.6.2", default-features = false }
+dotenvy = { version = "0.15.7", default-features = false }
+metrics = { version = "0.24.1", default-features = false }
+metrics-derive = { version = "0.1", default-features = false }
+serde_json = { version = "1.0.143", default-features = false }
+testcontainers = { version = "0.23.1", default-features = false }
+tracing-subscriber = { version = "0.3.20", default-features = false }
+testcontainers-modules = { version = "0.11.2", default-features = false }
+metrics-exporter-prometheus = { version = "0.17.0", default-features = false }

--- a/crates/account-abstraction-core/Cargo.toml
+++ b/crates/account-abstraction-core/Cargo.toml
@@ -8,23 +8,23 @@ repository.workspace = true
 edition.workspace = true
 
 [dependencies]
-alloy-serde = { version = "1.0.41", default-features = false }
-serde.workspace = true
-alloy-rpc-types.workspace = true
-alloy-provider.workspace = true
-op-alloy-network.workspace = true
-alloy-primitives = { workspace = true }
-reth-rpc-eth-types.workspace = true
-tokio.workspace = true
-jsonrpsee.workspace = true
-async-trait = { workspace = true }
-alloy-sol-types.workspace = true
-anyhow.workspace = true
-rdkafka.workspace = true
-serde_json.workspace = true
 tips-core.workspace = true
-tracing.workspace = true
+serde = { workspace = true, features = ["std", "derive"] }
+tokio = { workspace = true, features = ["full"] }
+tracing = { workspace = true, features = ["std"] }
+anyhow = { workspace = true, features = ["std"] }
+rdkafka = { workspace = true, features = ["tokio", "libz"] }
+jsonrpsee = { workspace = true, features = ["server", "macros"] }
+serde_json = { workspace = true, features = ["std"] }
+async-trait.workspace = true
+alloy-serde.workspace = true
+alloy-sol-types.workspace = true
+alloy-primitives = { workspace = true, features = ["map-foldhash", "serde"] }
+alloy-rpc-types = { workspace = true, features = ["eth"] }
+alloy-provider = { workspace = true, features = ["reqwest"] }
+op-alloy-network.workspace = true
+reth-rpc-eth-types.workspace = true
 
 [dev-dependencies]
-alloy-primitives.workspace = true
 wiremock.workspace = true
+alloy-primitives = { workspace = true, features = ["map-foldhash", "serde"] }

--- a/crates/audit/Cargo.toml
+++ b/crates/audit/Cargo.toml
@@ -13,28 +13,28 @@ path = "src/bin/main.rs"
 
 [dependencies]
 tips-core = { workspace = true, features = ["test-utils"] }
-tokio = { workspace = true }
-tracing = { workspace = true }
-tracing-subscriber = { workspace = true }
-anyhow = { workspace = true }
-serde = { workspace = true }
-serde_json = { workspace = true }
-uuid = { workspace = true }
-async-trait = { workspace = true }
-alloy-primitives = { workspace = true }
-alloy-consensus = { workspace = true }
-alloy-provider = { workspace = true }
-op-alloy-consensus = { workspace = true }
-clap = { workspace = true }
-dotenvy = { workspace = true }
-rdkafka = { workspace = true }
-aws-config = { workspace = true }
-aws-sdk-s3 = { workspace = true }
-aws-credential-types = { workspace = true }
-bytes = { workspace = true }
-metrics = { workspace = true }
-metrics-derive = { workspace = true }
+bytes.workspace = true
+metrics.workspace = true
+dotenvy.workspace = true
+async-trait.workspace = true
+metrics-derive.workspace = true
+alloy-primitives = { workspace = true, features = ["map-foldhash", "serde"] }
+tokio = { workspace = true, features = ["full"] }
+serde = { workspace = true, features = ["std", "derive"] }
+uuid = { workspace = true, features = ["v4", "serde"] }
+tracing = { workspace = true, features = ["std"] }
+anyhow = { workspace = true, features = ["std"] }
+serde_json = { workspace = true, features = ["std"] }
+rdkafka = { workspace = true, features = ["tokio", "libz"] }
+alloy-consensus = { workspace = true, features = ["std"] }
+alloy-provider = { workspace = true, features = ["reqwest"] }
+op-alloy-consensus = { workspace = true, features = ["std", "k256", "serde"] }
+clap = { version = "4.5.47", features = ["std", "derive", "env"] }
+tracing-subscriber = { workspace = true, features = ["std", "fmt", "env-filter", "json"] }
+aws-config = { workspace = true, features = ["default-https-client", "rt-tokio"] }
+aws-sdk-s3 = { workspace = true, features = ["rustls", "default-https-client", "rt-tokio"] }
+aws-credential-types.workspace = true
 
 [dev-dependencies]
-testcontainers = { workspace = true }
-testcontainers-modules = { workspace = true }
+testcontainers = { workspace = true, features = ["blocking"] }
+testcontainers-modules = { workspace = true, features = ["postgres", "kafka", "minio"] }

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -11,23 +11,22 @@ edition.workspace = true
 test-utils = ["dep:alloy-signer-local", "dep:op-alloy-rpc-types"]
 
 [dependencies]
-uuid.workspace = true
-alloy-primitives.workspace = true
-alloy-consensus.workspace = true
-alloy-provider.workspace = true
-op-alloy-consensus.workspace = true
-alloy-serde = { version = "1.0.41", default-features = false }
-alloy-signer-local = { workspace = true, optional = true }
-op-alloy-rpc-types = { workspace = true, optional = true }
-tracing.workspace = true
-tracing-subscriber.workspace = true
+serde = { workspace = true, features = ["std", "derive"] }
+uuid = { workspace = true, features = ["v4", "serde"] }
+tracing = { workspace = true, features = ["std"] }
 op-alloy-flz.workspace = true
-serde.workspace = true
-alloy-rpc-types.workspace = true
-metrics-exporter-prometheus.workspace = true
-
+alloy-serde.workspace = true
+alloy-primitives = { workspace = true, features = ["map-foldhash", "serde"] }
+alloy-consensus = { workspace = true, features = ["std"] }
+alloy-rpc-types = { workspace = true, features = ["eth"] }
+alloy-provider = { workspace = true, features = ["reqwest"] }
+op-alloy-consensus = { workspace = true, features = ["std", "k256", "serde"] }
+alloy-signer-local = { workspace = true, optional = true }
+op-alloy-rpc-types = { workspace = true, features = ["std"], optional = true }
+tracing-subscriber = { workspace = true, features = ["std", "fmt", "ansi", "env-filter", "json"] }
+metrics-exporter-prometheus = { workspace = true, features = ["http-listener"] }
 
 [dev-dependencies]
 alloy-signer-local.workspace = true
-op-alloy-rpc-types.workspace = true
-serde_json.workspace = true
+serde_json = { workspace = true, features = ["std"] }
+op-alloy-rpc-types = { workspace = true, features = ["std"] }

--- a/crates/ingress-rpc/Cargo.toml
+++ b/crates/ingress-rpc/Cargo.toml
@@ -15,31 +15,31 @@ path = "src/bin/main.rs"
 tips-core.workspace = true
 tips-audit.workspace = true
 account-abstraction-core.workspace = true
-jsonrpsee.workspace = true
-alloy-primitives.workspace = true
-op-alloy-network.workspace = true
-alloy-provider.workspace = true
-tokio.workspace = true
-tracing.workspace = true
-anyhow.workspace = true
-clap.workspace = true
 url.workspace = true
-alloy-consensus.workspace = true
-op-alloy-consensus.workspace = true
-dotenvy.workspace = true
-rdkafka.workspace = true
-reth-rpc-eth-types.workspace = true
-serde_json.workspace = true
-async-trait.workspace = true
-backon.workspace = true
-op-revm.workspace = true
-alloy-signer-local.workspace = true
-reth-optimism-evm.workspace = true
 metrics.workspace = true
+dotenvy.workspace = true
+op-revm.workspace = true
+async-trait.workspace = true
 metrics-derive.workspace = true
-axum.workspace = true
+alloy-primitives = { workspace = true, features = ["map-foldhash", "serde"] }
+alloy-signer-local.workspace = true
+op-alloy-network.workspace = true
+reth-optimism-evm.workspace = true
+reth-rpc-eth-types.workspace = true
+tokio = { workspace = true, features = ["full"] }
+tracing = { workspace = true, features = ["std"] }
+anyhow = { workspace = true, features = ["std"] }
+serde_json = { workspace = true, features = ["std"] }
+axum = { workspace = true, features = ["tokio", "http1", "json"] }
+rdkafka = { workspace = true, features = ["tokio", "libz"] }
+backon = { workspace = true, features = ["std", "tokio-sleep"] }
+jsonrpsee = { workspace = true, features = ["server", "macros"] }
+alloy-consensus = { workspace = true, features = ["std"] }
+alloy-provider = { workspace = true, features = ["reqwest"] }
+op-alloy-consensus = { workspace = true, features = ["std", "k256", "serde"] }
+clap = { version = "4.5.47", features = ["std", "derive", "env"] }
 
 [dev-dependencies]
 wiremock.workspace = true
-jsonrpsee = { workspace = true, features = ["server", "http-client", "macros"] }
 mockall = "0.13"
+jsonrpsee = { workspace = true, features = ["server", "http-client", "macros"] }

--- a/crates/system-tests/Cargo.toml
+++ b/crates/system-tests/Cargo.toml
@@ -9,54 +9,43 @@ license.workspace = true
 path = "src/lib.rs"
 
 [dependencies]
-tips-audit = { workspace = true }
-tips-core = { workspace = true }
+tips-core.workspace = true
+tips-audit.workspace = true
 tips-ingress-rpc = { path = "../ingress-rpc" }
-
-alloy-primitives = { workspace = true }
-alloy-provider = { workspace = true }
-alloy-signer-local = { workspace = true }
-alloy-consensus = { workspace = true }
-alloy-network = { workspace = true }
-
-op-alloy-network = { workspace = true }
-op-alloy-consensus = { workspace = true }
-
-tokio = { workspace = true }
-async-trait = { workspace = true }
-
-aws-sdk-s3 = { workspace = true }
-aws-config = { workspace = true }
-aws-credential-types = { workspace = true }
-
-rdkafka = { workspace = true }
-
-serde = { workspace = true }
-serde_json = { workspace = true }
-
-anyhow = { workspace = true }
-
-uuid = { workspace = true }
-tracing = { workspace = true }
-tracing-subscriber = { workspace = true }
-url = { workspace = true }
-
-reqwest = { version = "0.12.12", features = ["json"] }
-bytes = { workspace = true }
+url.workspace = true
+bytes.workspace = true
+op-revm.workspace = true
+async-trait.workspace = true
+alloy-network.workspace = true
+alloy-primitives = { workspace = true, features = ["map-foldhash", "serde"] }
+alloy-signer-local.workspace = true
+op-alloy-network.workspace = true
+aws-credential-types.workspace = true
 hex = "0.4.3"
-jsonrpsee = { workspace = true }
-op-revm = { workspace = true }
-
-# Load test dependencies
-clap = { version = "4.5", features = ["derive", "env"] }
-indicatif = "0.17"
 rand = "0.8"
-rand_chacha = "0.3"
 dashmap = "6.0"
+indicatif = "0.17"
+rand_chacha = "0.3"
+tokio = { workspace = true, features = ["full"] }
+serde = { workspace = true, features = ["std", "derive"] }
+uuid = { workspace = true, features = ["v4", "serde"] }
+tracing = { workspace = true, features = ["std"] }
+anyhow = { workspace = true, features = ["std"] }
+serde_json = { workspace = true, features = ["std"] }
+rdkafka = { workspace = true, features = ["tokio", "libz"] }
+jsonrpsee = { workspace = true, features = ["server", "macros"] }
+alloy-consensus = { workspace = true, features = ["std"] }
+alloy-provider = { workspace = true, features = ["reqwest"] }
+op-alloy-consensus = { workspace = true, features = ["std", "k256", "serde"] }
+reqwest = { version = "0.12.12", features = ["json"] }
+clap = { version = "4.5", features = ["std", "derive", "env"] }
+tracing-subscriber = { workspace = true, features = ["std", "fmt", "env-filter", "json"] }
+aws-config = { workspace = true, features = ["default-https-client", "rt-tokio"] }
+aws-sdk-s3 = { workspace = true, features = ["rustls", "default-https-client", "rt-tokio"] }
 
 [dev-dependencies]
-tokio = { workspace = true, features = ["test-util"] }
-testcontainers = { workspace = true }
-testcontainers-modules = { workspace = true }
 serial_test = "3"
+tokio = { workspace = true, features = ["full", "test-util"] }
+testcontainers = { workspace = true, features = ["blocking"] }
+testcontainers-modules = { workspace = true, features = ["postgres", "kafka", "minio"] }
 


### PR DESCRIPTION
### Description

Adds lints to the workspace cargo manifest.

Cleans up the dependencies and removes workspace-level feature flags to avoid leakage.

Future PRs will apply these lints to each crate through it's `Cargo.toml`.